### PR TITLE
Fix for improper bprint call

### DIFF
--- a/source/pr_cmds.c
+++ b/source/pr_cmds.c
@@ -283,14 +283,14 @@ PF_bprint
 
 broadcast print to everyone on server
 
-bprint(value)
+bprint(style, value)
 =================
 */
 void PF_bprint (void)
 {
-	char		*s;
-
-	s = PF_VarString(0);
+	// 
+	float style = G_FLOAT(OFS_PARM0);
+	char *s = PF_VarString(1);
 	SV_BroadcastPrintf ("%s", s);
 }
 


### PR DESCRIPTION
We have forgotten to get the style of the bprint, thus causing hard crash curing ClientDisconnect